### PR TITLE
MetaGraph(::GraphMol)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 FIGlet = "3064a664-84fe-4d92-92c7-ed492f3d8fae"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
+MolecularGraph = "6c89ec66-9cd8-5372-9f91-fabc50dd27fd"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
@@ -14,7 +15,8 @@ Aqua = "0.5"
 FIGlet = "0.2"
 Graphs = "1.7"
 MetaGraphs = "0.7"
-julia = "1.6, 1.7, 1.8"
+MolecularGraph = "0.11"
+julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/MolecularGraphKernels.jl
+++ b/src/MolecularGraphKernels.jl
@@ -1,10 +1,11 @@
 module MolecularGraphKernels
 
-using FIGlet, Graphs, MetaGraphs, SparseArrays
+using FIGlet, Graphs, MetaGraphs, MolecularGraph, SparseArrays
 
 include.([
     "direct_product_graph.jl"
     "random_walk_graph_kernel.jl"
+    "graph_conversion.jl"
 ])
 
 
@@ -17,6 +18,6 @@ function banner()
 end
 
 
-export direct_product_graph, fixed_length_rw_kernel
+export direct_product_graph, fixed_length_rw_kernel, MetaGraph
 
 end # module MolecularGraphKernels

--- a/src/graph_conversion.jl
+++ b/src/graph_conversion.jl
@@ -1,0 +1,17 @@
+"""
+    g = MetaGraph(mol)
+
+Convert a `GraphMol` object into the corresponding `MetaGraph`
+"""
+function MetaGraph(mol::G)::MetaGraph where G <: GraphMol
+    g = MetaGraph(length(mol.nodeattrs))
+    # atoms
+    for v in vertices(g)
+        set_prop!(g, v, :symbol, mol.nodeattrs[v].symbol)
+    end
+    # bonds
+    for (e, att) in enumerate(mol.edgeattrs)
+        add_edge!(g, mol.edges[e]..., Dict(:order => att.order))
+    end
+    return g
+end

--- a/test/direct_product_graph.jl
+++ b/test/direct_product_graph.jl
@@ -36,4 +36,8 @@ using Graphs, MetaGraphs, MolecularGraphKernels, SparseArrays, Test
     set_prop!(C, 2, :symbol, :H)
 
     @test_throws AssertionError direct_product_graph(A, C)
+
+    set_prop!(C, 1, 2, :order, 1)
+
+    @test direct_product_graph(C, C) == direct_product_graph(MetaGraph(smilestomol("[H]-[H]")), C)
 end

--- a/test/graph_conversion.jl
+++ b/test/graph_conversion.jl
@@ -1,0 +1,16 @@
+using Graphs, MetaGraphs, MolecularGraph, MolecularGraphKernels, Test
+
+@testset "graph_conversion" begin
+    A = smilestomol("C1CC=1")
+    B = MetaGraph(3)
+
+    add_edge!(B, 1, 2, Dict(:order => :single))
+    add_edge!(B, 2, 3, Dict(:order => :single))
+    add_edge!(B, 3, 1, Dict(:order => :double))
+
+    set_prop!(B, 1, :symbol, :C)
+    set_prop!(B, 2, :symbol, :C)
+    set_prop!(B, 3, :symbol, :C)
+
+    @test MetaGraph(A) == B
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using MolecularGraphKernels
 MolecularGraphKernels.banner()
 
 include.([
+    "graph_conversion.jl"
     "direct_product_graph.jl"
     "random_walk_graph_kernel.jl"
     "docs.jl"


### PR DESCRIPTION
adds type conversion function for `GraphMol` -> `MetaGraph`