### PR TITLE
Distrib-latency

### DIFF
--- a/.github/workflows/CI_Build.yml
+++ b/.github/workflows/CI_Build.yml
@@ -62,11 +62,8 @@ jobs: # run in parallel within workflow
       - name: build package
         uses: julia-actions/julia-buildpkg@latest
 
-      - name: multi-process setup
-        run: julia --color=yes -e 'import Pkg; Pkg.develop(path=".")'
-
       - name: test
-        run: julia -p 2 --color=yes --project test/gram_matrix.jl
+        run: julia --color=yes --project test/distributed.jl
 
   aqua-jl:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Manifest.toml
 docs/build/*
 *.pdf
 __pycache__
+.vscode

--- a/test/distributed.jl
+++ b/test/distributed.jl
@@ -1,0 +1,43 @@
+using Distributed
+
+# spin up workers
+addprocs(2)
+
+# ensure environment synchronization
+@everywhere begin
+    import Pkg
+    Pkg.activate(".")
+    Pkg.instantiate()
+end
+
+using MolecularGraph, MolecularGraphKernels, Test
+
+@testset verbose = true "Gram matrix" begin
+    graphs = MetaGraph.(smilestomol.([
+        "c1ccccc1"
+        "NC=O"
+        "C(NC=O)NC=O"
+    ]))
+
+    @testset "Built-In Kernel (CCSI)" begin
+        csi_gm = gram_matrix(ccsi, graphs)
+
+        @test size(csi_gm) == (3, 3)
+        @test csi_gm[1, 2] == csi_gm[2, 1] == ccsi(graphs[1], graphs[2])
+        @test csi_gm[3, 2] == csi_gm[3, 2] == ccsi(graphs[3], graphs[2])
+        @test csi_gm[2, 2] == ccsi(graphs[2], graphs[2])
+    end
+
+    @testset "Custom Kernels" begin
+        kernel1(g₁, g₂) = 1
+        @test sum(gram_matrix(kernel1, graphs)) == 9
+
+        kernel2(g₁, g₂; k=2) = k
+        @test sum(gram_matrix(kernel2, graphs)) == sum(gram_matrix(kernel2, graphs; k=4)) / 2 == 18
+    end
+
+    @testset "Normalization" begin
+        K = gram_matrix(random_walk, graphs; l=3)
+        @test gram_matrix(random_walk, graphs; l=3, normalize=true) == gm_norm(K)
+    end
+end

--- a/test/distributed.jl
+++ b/test/distributed.jl
@@ -33,7 +33,9 @@ using MolecularGraph, MolecularGraphKernels, Test
         @test sum(gram_matrix(kernel1, graphs)) == 9
 
         kernel2(g₁, g₂; k=2) = k
-        @test sum(gram_matrix(kernel2, graphs)) == sum(gram_matrix(kernel2, graphs; k=4)) / 2 == 18
+        @test sum(gram_matrix(kernel2, graphs)) ==
+              sum(gram_matrix(kernel2, graphs; k=4)) / 2 ==
+              18
     end
 
     @testset "Normalization" begin


### PR DESCRIPTION
refactor parallel calc tests to use addprocs instead of -p